### PR TITLE
Improve lazy loading documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,6 @@ Read more on [readthedocs.io](https://ancpbids.readthedocs.io)
 
 Since v0.5, JSON and TSV file contents are loaded lazily and cached only via weak
 references. This means memory is automatically freed once those objects are no
-longer referenced in your code.
+longer referenced in your code.  Accessing ``myfile.contents`` triggers loading
+the file on demand; pass ``DatasetOptions(load_contents=True)`` to load all
+contents eagerly.

--- a/ancpbids/__init__.py
+++ b/ancpbids/__init__.py
@@ -41,7 +41,9 @@ class DatasetOptions(dict):
     load_contents: bool = False
     """If ``True``, JSON and TSV files are read eagerly when calling
         :func:`load_dataset`.  By default this is ``False`` so file contents are
-        loaded lazily on first access via the ``contents`` attribute."""
+        loaded lazily on first access via the ``contents`` attribute.  Loaded
+        contents are cached only via weak references so memory can be reclaimed
+        when they are no longer used."""
 
 
 def load_dataset(base_dir: str, options: Optional[DatasetOptions] = None):

--- a/ancpbids/plugins/plugin_dsloader.py
+++ b/ancpbids/plugins/plugin_dsloader.py
@@ -69,6 +69,8 @@ class DatasetPopulationPlugin(DatasetPlugin):
                 mdfile = MetadataFile()
             mdfile.parent_object_ = folder
             mdfile.update(file)
+            # When ``load_contents`` is False we keep contents unloaded until
+            # the ``contents`` property is accessed (lazy loading).
             if self.options.load_contents:
                 mdfile.contents = mdfile.load_contents()
             folder.files.remove(file)
@@ -87,6 +89,7 @@ class DatasetPopulationPlugin(DatasetPlugin):
                 newfile = TSVFile()
             newfile.parent_object_ = folder
             newfile.update(file)
+            # Defer reading large TSV files unless eager loading was requested
             if self.options.load_contents:
                 newfile.contents = newfile.load_contents()
             folder.files.remove(file)
@@ -264,6 +267,8 @@ class DatasetPopulationPlugin(DatasetPlugin):
         if not file:
             return
         json_object = None
+        # JSON files can be large; only read them immediately if eager loading
+        # was requested via ``DatasetOptions.load_contents``
         if self.options.load_contents:
             json_object = file.load_contents()
         if json_object:

--- a/ancpbids/plugins/plugin_files_handlers.py
+++ b/ancpbids/plugins/plugin_files_handlers.py
@@ -13,8 +13,11 @@ def read_yaml(file_path: str, **kwargs):
 
 
 def read_json(file_path: str, **kwargs):
-    """Reads a JSON file.  Large files are accessed via ``mmap`` to reduce
-    memory overhead."""
+    """Reads a JSON file used by lazy loading.
+
+    Large files are accessed via ``mmap`` to keep memory usage low when file
+    contents are only needed transiently.
+    """
     import json
     import mmap
     with open(file_path, "r") as stream:

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -19,6 +19,9 @@ i.e. if you added new files to your dataset after loading it, you have to reload
 
 JSON and TSV files are loaded lazily. Their contents are cached via weak
 references and automatically cleared from memory once no reference is held.
+Accessing ``file.contents`` will transparently read the file the first time and
+cache the result.  To force eager loading during dataset creation, pass
+``DatasetOptions(load_contents=True)`` to :func:`load_dataset`.
 
 Validate a BIDS dataset
 -----------------------------

--- a/docs/source/userDocMEG.rst
+++ b/docs/source/userDocMEG.rst
@@ -277,16 +277,18 @@ Access file contents
 Now we know how to query our data to gather information about the dataset and to locate specific files which we
 will need for our analysis. In order to work with these files in our workflows we have to **access** them.
 
-For accessing the contents of our files we can use the **load_contents()** function. Keep in mind that in order to
-successfully load the contents of the file the **return_type** parameter of the **get()** function should not be
-specified sticking to its default value 'dict'.
+Files expose a ``contents`` property which loads the data lazily on first
+access.  Alternatively you can call ``load_contents()`` explicitly.  The
+``return_type`` parameter of :func:`get` should remain at its default ``'dict'``
+for this to work correctly.
 
-We can then load the contents of the first element of our dictionary to access the file, see the example below:
+We can then load the contents of the first element of our dictionary to access
+the file, see the example below:
 
 .. code-block:: python
 
-    events = layout.get(suffix='events',subject='009',task='deduction')
-    df_events = events[0].load_contents()
+    events = layout.get(suffix='events', subject='009', task='deduction')
+    df_events = events[0].contents
 This way you will be able to load the contents of the metadata and descriptive tabular files.
 @Erdal: für imaging data brauchen wir aber noch bibleotheken die die daten interpretieren können richtig?
 


### PR DESCRIPTION
## Summary
- clarify lazy loading feature in README and usage docs
- document usage of the `contents` property in MEG user guide
- expand comments in dataset loader and schema patches about lazy loading
- enhance DatasetOptions documentation
- add explanation to JSON file reader

## Testing
- `pytest -q tests/auto`

------
https://chatgpt.com/codex/tasks/task_e_68556a99f1848326b4aa3d927e18fc02